### PR TITLE
docs: fix typo in blog description #21

### DIFF
--- a/blogs/a-day-in-the-life-curriculum-intern-codedex-ellie-popoca.mdx
+++ b/blogs/a-day-in-the-life-curriculum-intern-codedex-ellie-popoca.mdx
@@ -1,6 +1,6 @@
 ---
 title: "A Day in the Life: Curriculum Intern @ Codédex"
-description: Welcome to the "A Day in the Life" series! In the second issue, we are spotlighting Ellie Popoca, an Information Science and Game Design major at the University of Illinoise Urbana-Champaign and an ex-Major League Hacking (MLH) coach, and our wonderful Curriculum Intern at Codédex this summer. ✨
+description: Welcome to the "A Day in the Life" series! In the second issue, we are spotlighting Ellie Popoca, an Information Science and Game Design major at the University of Illinois Urbana-Champaign and an ex-Major League Hacking (MLH) coach, and our wonderful Curriculum Intern at Codédex this summer. ✨
 author: Lillian McVeigh
 seoImageLink: https://firebasestorage.googleapis.com/v0/b/codedex-io.appspot.com/o/blogs%2Fa-day-in-the-life-curriculum-intern-codedex-ellie-popoca%2Fbanner.png?alt=media&token=7c74e895-86ef-4015-9206-5528d37ca7de
 dateCreated: 2023-08-21


### PR DESCRIPTION
# PR description:
- This PR fixes the typo found in the blog post description [a-day-in-the-life-curriculum-intern-codedex-ellie-popoca](https://github.com/codedex-io/blog/blob/main/blogs/a-day-in-the-life-curriculum-intern-codedex-ellie-popoca.mdx)

## Changes:
- Corrected the spelling of `Illinoise` to **`Illinois`**.

## Related issues:
- This PR closes #21.