### PR TITLE
Proposal of fix to a typo in the blog post holiday hackathon 2023 winners.

### DIFF
--- a/blogs/holiday-hackathon-2023-winners.mdx
+++ b/blogs/holiday-hackathon-2023-winners.mdx
@@ -101,7 +101,7 @@ A single-page React web app featuring an advent calendar that allows users to co
 **Tools:** HTML, CSS, JavaScript, jQuery, Vite, Firebase
 **Prize:** Codédex hoodie and annual sub
 
-Create and store holiday e-cards using templates and each cards gets a sharable link to send to family and friends! This was the only full-fledged web app among the submissions and the judges couldn't believe you even added authentication (Firebase). Such a rock solid presentation and documentation, too. 
+Create and store holiday e-cards using templates, and each card gets a shareable link to send to family and friends! This was the only full-fledged web app among the submissions and the judges couldn't believe you even added authentication (Firebase). Such a rock solid presentation and documentation, too. 
 
 <div style={{ display: "flex", justifyContent: "center", marginBottom: "1.2rem", transform: "scale(.9)" }}>
   <a className="nes-btn is-warning" href="https://www.codedex.io/community/monthly-challenge/submission/bONlraRWkymyE50hhPT4" target="_blank" and rel="noopener noreferrer">View Project</a>


### PR DESCRIPTION
Hello team,

I would like to propose a fix for a typo from this [blog post](https://www.codedex.io/blog/holiday-hackathon-2023-winners).

The sentence:

_'Create and store holiday e-cards using templates and each cards gets a sharable link to send to family and friends!'_

Could be replaced with:

_'Create and store holiday e-cards using templates, and each card gets a shareable link to send to family and friends!'_

Let's get it. 🚀