### PR TITLE
Proposal of fix for typo in codedex-github-edu blog post.

### DIFF
--- a/blogs/codedex-github-edu.mdx
+++ b/blogs/codedex-github-edu.mdx
@@ -52,7 +52,7 @@ To qualify for student benefits, you must:
 - Be currently enrolled in a degree or diploma granting course of study from a recognized educational institution.
 - Be able to provide documentation from your school that shows your student status.
 
-#### Get started w GitHub Student Developer Pack
+#### Get started with GitHub Student Developer Pack
 
 If you are already verified via GitHub Education, go to the [GitHub Student Developer Pack](https://education.github.com/pack) to find the Codédex tile (scroll all the way down).
 


### PR DESCRIPTION
Hello team,

I would like to propose a fix to this [blog post](https://www.codedex.io/blog/codedex-github-edu). 

The header _'Get started w GitHub Student Developer Pack'_ could be replaced with _'Get started with GitHub Student Developer Pack'_.

