### PR TITLE
Proposal of fix for typo from blog post codedex-creator-program-launch.

### DIFF
--- a/blogs/codedex-creator-program-launch.mdx
+++ b/blogs/codedex-creator-program-launch.mdx
@@ -24,7 +24,7 @@ The long story? It’s our first-ever 2-month ambassador program of Codédex lea
 
 If you’re a learner, you *might* know how much we value community here at Codédex (on-platform community, Discord server, raising your own virtual pet through #30NitesOfCode… well, the list goes on and on) and because of that, our ultimate goal for this program is to continue building community!
 
-We’ve united Codédex learners who are amazing content creators (amazing!!!) and most importantly, storytellers of how coding has changed and influenced their life. 
+We’ve united Codédex learners who are amazing content creators (amazing!!!) and most importantly, storytellers of how coding has changed and influenced their lives. 
 
 They’ve inspired us and we hope their stories inspire you too. 🌟
 


### PR DESCRIPTION
Hello team,

I would like to propose a fix to a typo from this [blog post](https://www.codedex.io/blog/codedex-creator-program-launch).

The sentence: 

_'We’ve united Codédex learners who are amazing content creators (amazing!!!) and most importantly, storytellers of how coding has changed and influenced their life.'_

Could be replaced with:

_'We’ve united Codédex learners who are amazing content creators (amazing!!!) and most importantly, storytellers of how coding has changed and influenced their lives.'_

In order to maintain the singular/plural agreement.

Let's get it. 