### PR TITLE
Edited the intern.nasa.gov link to incl. https://

### DIFF
--- a/blogs/a-day-in-the-life-swe-intern-nasa-brandon-lam.mdx
+++ b/blogs/a-day-in-the-life-swe-intern-nasa-brandon-lam.mdx
@@ -27,7 +27,7 @@ I’m a SWE Intern at [NASA Glenn Research Center](https://en.wikipedia.org/wiki
 
 ##### How did you get the internship?
 
-I applied last December on [intern.nasa.gov](intern.nasa.gov) and got a call in March from my current mentor, Nancy. She was interested in my background and thought that I would be a good fit. She also mentioned she was judging for a NASA high school competition in my area and wondered if I’d like to help judge the event the next day. It was an opportunity to talk more about the position.
+I applied last December on [intern.nasa.gov](https://intern.nasa.gov) and got a call in March from my current mentor, Nancy. She was interested in my background and thought that I would be a good fit. She also mentioned she was judging for a NASA high school competition in my area and wondered if I’d like to help judge the event the next day. It was an opportunity to talk more about the position.
 
 So the next day, I skipped school and went. Upon arriving, I felt terrified, seeing that the other judges were three NASA employees plus myself. However, the event turned out to be fantastic, and I received valuable advice from the judges. Moreover, I had the opportunity to network with them, and as a result, I was later accepted into my internship! 
 


### PR DESCRIPTION
(This is a duplicate of the /37 pull request but I have messed up on my end and can't figure out how to re-open that one)

Included "https://" with intern.nasa.gov link

In some instances (including GitHub), middle-mouse-clicking the link will redirect you to that page + intern.nasa.gov

For instance, https://github.com/codedex-io/blog/blob/main/blogs/a-day-in-the-life-swe-intern-nasa-brandon-lam.mdx redirects to https://github.com/codedex-io/blog/blob/main/blogs/intern.nasa.gov