### PR TITLE
Misstypos Link

### DIFF
--- a/blogs/back-to-school-campus-tour-2024
+++ b/blogs/back-to-school-campus-tour-2024
@@ -63,7 +63,7 @@ Find Sonny, Naomi, and Jackie at the Codédex booth in the mentor / sponsor sect
   <img src="https://i.imgur.com/EqSSib3.png" width="175"/>
 </div>
 
-#### [Mon 9/23: Pizza Party @ NYU](https://https://linkedin.com/company/codedex)
+#### [Mon 9/23: Pizza Party @ NYU](https://linkedin.com/company/codedex)
 
 Pizza Party at NYU Tandon (Maker EventSpace) in Brooklyn on Mon, Sep 23 from 4-7pm. We've partnered with [HackNYU](https://hacknyu.org) to bring you:
 


### PR DESCRIPTION
Fixed misstypos double https://https:// in Linkedin Link.