### PR TITLE
refactor(publish): modularize publishing logic

### DIFF
--- a/publish/index.js
+++ b/publish/index.js
@@ -1,31 +1,9 @@
-import firebaseAdmin from "firebase-admin";
 import fs from "fs";
 import path from "path";
-import { MeiliSearch } from "meilisearch";
 
-import { parseMarkdown } from "./parser.js";
-
-const client = new MeiliSearch({
-  host: process.env.MEILISEARCH_HOST,
-  apiKey: process.env.MEILISEARCH_API_KEY,
-});
-
-firebaseAdmin.initializeApp({
-  credential: firebaseAdmin.credential.cert({
-    type: "service_account",
-    project_id: "codedex-io",
-    private_key_id: process.env.private_key_id,
-    private_key: process.env.private_key,
-    client_email: process.env.client_email,
-    client_id: process.env.client_id,
-    auth_uri: "https://accounts.google.com/o/oauth2/auth",
-    token_uri: "https://oauth2.googleapis.com/token",
-    auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
-    client_x509_cert_url: process.env.client_cert_url,
-  }),
-});
-
-const firestore = firebaseAdmin.firestore();
+import { firestore } from "./lib/firebase.js";
+import { client } from "./lib/meilisearch.js";
+import { parseMarkdown } from "./parsers/mdx-parser.js";
 
 function getBlogsFileNames() {
   return fs

--- a/publish/lib/firebase.js
+++ b/publish/lib/firebase.js
@@ -1,0 +1,18 @@
+import firebaseAdmin from "firebase-admin";
+
+firebaseAdmin.initializeApp({
+  credential: firebaseAdmin.credential.cert({
+    type: "service_account",
+    project_id: "codedex-io",
+    private_key_id: process.env.private_key_id,
+    private_key: process.env.private_key,
+    client_email: process.env.client_email,
+    client_id: process.env.client_id,
+    auth_uri: "https://accounts.google.com/o/oauth2/auth",
+    token_uri: "https://oauth2.googleapis.com/token",
+    auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
+    client_x509_cert_url: process.env.client_cert_url,
+  }),
+});
+
+export const firestore = firebaseAdmin.firestore();

--- a/publish/lib/meilisearch.js
+++ b/publish/lib/meilisearch.js
@@ -1,0 +1,6 @@
+import { MeiliSearch } from "meilisearch";
+
+export const client = new MeiliSearch({
+  host: process.env.MEILISEARCH_HOST,
+  apiKey: process.env.MEILISEARCH_API_KEY,
+});

--- a/publish/parsers/mdx-parser.js
+++ b/publish/parsers/mdx-parser.js
@@ -66,4 +66,3 @@ export async function parseMarkdown({ markdown }) {
 
   return { source, content, data };
 }
-


### PR DESCRIPTION
This pull request refactors the initialization of external services and improves code organization in the `publish` directory. The main changes involve moving the setup of Firebase and MeiliSearch clients into their own modules, and renaming the Markdown parser file for clarity.

**Refactoring and code organization:**

* Moved Firebase initialization and Firestore export from `index.js` to a new module `lib/firebase.js`, and updated imports accordingly. [[1]](diffhunk://#diff-937ba470dd3cd2ba8f0bd1bd839d279d55f04400209577ba2da06b4c4eacd3bbL1-R6) [[2]](diffhunk://#diff-56b400f209c999a84e09a4b026cb9da37d0a577df476251cce34727a7a8303f2R1-R18)
* Moved MeiliSearch client initialization from `index.js` to a new module `lib/meilisearch.js`, and updated imports accordingly. [[1]](diffhunk://#diff-937ba470dd3cd2ba8f0bd1bd839d279d55f04400209577ba2da06b4c4eacd3bbL1-R6) [[2]](diffhunk://#diff-c2f608ed17e5a34839c7ea7d4b670b6bd66023b349d1d6b7ea068fcb65dde211R1-R6)
* Renamed the Markdown parser file from `parser.js` to `parsers/mdx-parser.js` for better clarity and organization, and updated the import in `index.js`. [[1]](diffhunk://#diff-937ba470dd3cd2ba8f0bd1bd839d279d55f04400209577ba2da06b4c4eacd3bbL1-R6) [[2]](diffhunk://#diff-0126cba09c491b467605026d7c2b516536b36c49c8e2796ae1ad4abbd73b3f2eL69)