### PR TITLE
Updates discord and other xp related locks or mentions

### DIFF
--- a/blogs/2023/certificates.mdx
+++ b/blogs/2023/certificates.mdx
@@ -43,13 +43,13 @@ For example, here are the steps for The Legend of Python:
 
 - 1️⃣ Complete chapters 1-4.
 
-- 2️⃣ Choose a Checkpoint (pick between [Area Calculator](https://www.codedex.io/python/mid-project/area-calculator), [RPS](https://www.codedex.io/python/mid-project/rock-paper-scissors), or [Terminal Adventure](https://www.codedex.io/python/mid-project/terminal-adventure-game)). Once you’ve completed your checkpoint project, share it in the **#checkpoint** Discord channel. Our team will review your submission within 2-3 business days.
+- 2️⃣ Choose a Checkpoint (pick between **Area Calculator**, **RPS**, or **Terminal Adventure** in the Python course). Once you’ve completed your checkpoint project, share it in the **#checkpoint** Discord channel. Our team will review your submission within 2-3 business days.
 
 - 3️⃣ Continue to complete chapters 5-8.
 
-- 4️⃣ Dive into the [Final Project](https://www.codedex.io/python/final-project). Post your submission in the **#final-project** Discord channel for a team review.
+- 4️⃣ Dive into the **Final Project** in the Python course. Post your submission in the **#final-project** Discord channel for a team review.
 
-- 5️⃣ Once you’ve completed everything, fill out [this form to request your certificate](https://59ty7awbpjd.typeform.com/to/z9b4XvIc). 
+- 5️⃣ Once you’ve completed everything, fill out the form to request your certificate.
 
 You will receive an email and a ping in the **#certificates** channel when you get it!
 

--- a/blogs/2023/codedexs-birthday-celebration.mdx
+++ b/blogs/2023/codedexs-birthday-celebration.mdx
@@ -17,7 +17,7 @@ With Codédex's first anniversary just around the corner, we’re carving out so
 <ul>
   <li><strong>🆕 Course Drop</strong>: The long-awaited, third and final course in The Origins Trilogy will be released.</li>
   <li><strong>🆕 Practice Feature</strong>: Challenge Packs! Each includes a handful of code challenges to practice your programming chops outside of Codédex courses! It’s time to get your reps in.</li>
-  <li><strong>🎟️ Community Raffle</strong>: We’ll be giving out limited edition Codédex merch! Keep an eye on the <a href="https://discord.com/channels/960713185055375478/992694461714927686/1110205145834336378" target="_blank">#announcements</a> channel in Discord early next week! ✨</li>
+  <li><strong>🎟️ Community Raffle</strong>: We’ll be giving out limited edition Codédex merch! Keep an eye on the #announcements channel in Discord early next week! ✨</li>
   <li><strong>💬 Special AMA</strong>: Codédex Engineers, Dharma and Asiqur, will share their journey learning to code and experience building Codédex as well as answer questions from the community, Q&A style!</li>
   <li><strong>😱 Final Surprise</strong>: And... there's one more surprise to be revealed that day!</li>
 </ul>

--- a/blogs/2023/discord-unlock.mdx
+++ b/blogs/2023/discord-unlock.mdx
@@ -1,6 +1,6 @@
 ---
 title: Discord Unlock
-description: Let's open the floodgate! 🌊 The Codédex Discord server is now unlockable at 100 XP...
+description: Let's open the floodgate! 🌊 The Codédex Discord server is now unlockable...
 author: Sonny Li
 dateCreated: 2023-01-28
 seoImageLink: https://firebasestorage.googleapis.com/v0/b/codedex-io.appspot.com/o/blogs%2Fdiscord-unlock%2Fbanner.gif?alt=media&token=89206ff1-0f40-4461-952f-3b486f54697a 
@@ -18,3 +18,5 @@ We are making our Discord server an unlockable feature! If you reach **100 XP**,
 See you there. 😊
 
 P.S. Make sure to introduce yourself in the **#introductions** channel!
+
+**Update:** The **100 XP** requirement above is no longer in effect and the [Discord server](https://discord.gg/vSKEhP9fY2) is now open to everyone!

--- a/blogs/2023/levels-and-ranks.mdx
+++ b/blogs/2023/levels-and-ranks.mdx
@@ -44,8 +44,8 @@ Here's a look from level 1 to 9:
 | Level | Rank   | XP to Unlock | Rewards |
 | ----- | ------ | ------------ | ------- |
 | Lvl 1 | Bronze | N/A          | N/A     |
-| Lvl 2 | Bronze | 100 XP       | Discord |
-| Lvl 3 | Bronze | 250 XP       | OPC     |
+| Lvl 2 | Bronze | 100 XP       | OPC     |
+| Lvl 3 | Bronze | 250 XP       | ???     |
 | Lvl 4 | Bronze | 500 XP       | ???     |
 | Lvl 5 | Bronze | 750 XP       | ???     |
 | Lvl 6 | Silver | 1000 XP      | ???     |

--- a/blogs/2023/product-update-v0-7.mdx
+++ b/blogs/2023/product-update-v0-7.mdx
@@ -15,7 +15,7 @@ The first update of 2023 is here. Update v0.7 is LIVE! 🚀
 - 🖼 Landing Page
 - 🌋 HTML Course
 - 🗞 Codédex Blog
-- 🔑 Discord Unlock (100 XP)
+- 🔑 Discord Unlock Popup
 - 👤 User Profiles 2.0
 - 🏫 Educator Dashboard
 - 📱 Mobile View Update

--- a/blogs/2024/codedex-creator-program-launch.mdx
+++ b/blogs/2024/codedex-creator-program-launch.mdx
@@ -53,7 +53,7 @@ Follow us to stay connected:
 
 And who knows?! Stay tuned for our next cohort…?! 👀
 
-If you're interested in being a Codédex Creator in our next cohort, [submit a form here](https://codedex.typeform.com/to/bL3Id8e9).
+If you're interested in being a Codédex Creator in our next cohort, [submit a form here](https://form.typeform.com/to/bL3Id8e9).
 
 From the bottom of our queues to the top of our stacks, thank you ALL for being a part of our community. And thank you to our [#CodedexCreator](https://www.instagram.com/explore/tags/codedexcreator/) besties for sharing their stories and being a part of this journey with us. This is just the beginning of our efforts to empower the next wave of builders. 🚀
 

--- a/blogs/2024/codedex-creator-program-launch.mdx
+++ b/blogs/2024/codedex-creator-program-launch.mdx
@@ -23,7 +23,7 @@ The long story? It’s our first-ever 2-month ambassador program of Codédex lea
 
 ## What is the goal?
 
-If you’re a learner, you *might* know how much we value community here at Codédex (On-platform Community, Discord server, raising your own virtual pet through #30NitesOfCode… well, the list goes on and on) and because of that, our ultimate goal for this program is to continue building community!
+If you’re a learner, you *might* know how much we value community here at Codédex (On-Platform Community, Discord server, raising your own virtual pet through #30NitesOfCode… well, the list goes on and on) and because of that, our ultimate goal for this program is to continue building community!
 
 We’ve united Codédex learners who are amazing content creators (amazing!!!) and most importantly, storytellers of how coding has changed and influenced their lives. 
 

--- a/blogs/2024/codedex-creator-program-launch.mdx
+++ b/blogs/2024/codedex-creator-program-launch.mdx
@@ -23,7 +23,7 @@ The long story? It’s our first-ever 2-month ambassador program of Codédex lea
 
 ## What is the goal?
 
-If you’re a learner, you *might* know how much we value community here at Codédex (on-platform community, Discord server, raising your own virtual pet through #30NitesOfCode… well, the list goes on and on) and because of that, our ultimate goal for this program is to continue building community!
+If you’re a learner, you *might* know how much we value community here at Codédex (On-platform Community, Discord server, raising your own virtual pet through #30NitesOfCode… well, the list goes on and on) and because of that, our ultimate goal for this program is to continue building community!
 
 We’ve united Codédex learners who are amazing content creators (amazing!!!) and most importantly, storytellers of how coding has changed and influenced their lives. 
 

--- a/blogs/2024/codedex-github-edu.mdx
+++ b/blogs/2024/codedex-github-edu.mdx
@@ -44,7 +44,7 @@ Your CS professor will likely bore you, but we won’t. Our team promises to del
 
 We’ve designed our curriculum so that you’ll gain a strong foundation in coding fundamentals and that will help you put into practice what you last learned. At the end of each course, you’ll bring it full circle with a real-world project. Along the way, you’ll unlock bonus articles and cheat sheets that supplement what you learn in each chapter.
 
-And did I mention community?! We have a robust community on our platform & in Discord. Weekly, we host fun events such as Office Hours, Project Show & Tell, tech workshops ([Getting Started with GitHub](https://discord.gg/VAtARArQ?event=1207055343331442688) coming up!), [Monthly Challenges](https://www.codedex.io/community/monthly-challenge/february-2024), Watch Parties, and more.
+And did I mention community?! We have a robust community on our platform & in Discord. Weekly, we host fun events such as Office Hours, Project Show & Tell, tech workshops ([Getting Started with GitHub](https://discord.gg/vSKEhP9fY2) coming up!), [Monthly Challenges](https://www.codedex.io/community/monthly-challenge/february-2024), Watch Parties, and more.
 
 ## Wait! Do I qualify for this?
 

--- a/blogs/2025/12-cool-coding-project-ideas-for-beginners.mdx
+++ b/blogs/2025/12-cool-coding-project-ideas-for-beginners.mdx
@@ -42,7 +42,7 @@ Alright, let’s say you are convinced to start. But how do you actually build o
 
 ### Learn
 
-Once you’ve got an idea, you figure out which programming languages you need and which tools might be helpful for you. Google stuff, ask for guidance in the Codédex [Discord](https://discord.gg/vSKEhP9fY2) or the [On-platform Community](https://www.codedex.io/community), or simply use [ChatGPT](https://chatgpt.com).
+Once you’ve got an idea, you figure out which programming languages you need and which tools might be helpful for you. Google stuff, ask for guidance in the Codédex [Discord](https://discord.gg/vSKEhP9fY2) or the [On-Platform Community](https://www.codedex.io/community), or simply use [ChatGPT](https://chatgpt.com).
 
 For example, if I want to build cute little websites and desktop apps, I need the basics of HTML, CSS and JavaScript, plus Figma to design layouts, Photoshop or Canva to make illustrations, and yess… a good pencil and paper to sketch out my ideas. 😍
 

--- a/blogs/2025/12-cool-coding-project-ideas-for-beginners.mdx
+++ b/blogs/2025/12-cool-coding-project-ideas-for-beginners.mdx
@@ -42,7 +42,7 @@ Alright, let’s say you are convinced to start. But how do you actually build o
 
 ### Learn
 
-Once you’ve got an idea, you figure out which programming languages you need and which tools might be helpful for you. Google stuff, ask for guidance in the Codédex Discord or the on-platform [community](https://www.codedex.io/community), or simply use [ChatGPT](https://chatgpt.com).
+Once you’ve got an idea, you figure out which programming languages you need and which tools might be helpful for you. Google stuff, ask for guidance in the Codédex [Discord](https://discord.gg/vSKEhP9fY2) or the [On-platform Community](https://www.codedex.io/community), or simply use [ChatGPT](https://chatgpt.com).
 
 For example, if I want to build cute little websites and desktop apps, I need the basics of HTML, CSS and JavaScript, plus Figma to design layouts, Photoshop or Canva to make illustrations, and yess… a good pencil and paper to sketch out my ideas. 😍
 

--- a/blogs/2025/30-nites-of-code-revamp-2025.mdx
+++ b/blogs/2025/30-nites-of-code-revamp-2025.mdx
@@ -52,7 +52,7 @@ After posting, you can then feed your pet (optional for the challenge, but highl
 
 **Q: So what's different than before?**
 
-Before, adding daily progress required you to make a post on Twitter/X or the on-platform community (OPC), *then* submit a link to that post in the #30NitesOfCode page. Our new design simplifies this process to make it easier to submit progress every day.
+Before, adding daily progress required you to make a post on Twitter/X or the On-Platform Community (OPC), *then* submit a link to that post in the #30NitesOfCode page. Our new design simplifies this process to make it easier to submit progress every day.
 
 **Q: What if I have existing progress?**
 

--- a/blogs/2025/codedex-update-february-2025.mdx
+++ b/blogs/2025/codedex-update-february-2025.mdx
@@ -56,7 +56,7 @@ We redesigned our Project Showcase to feel more like a showcase (switched to a g
 
 ![Leaderboards page](https://i.imgur.com/XxKNWdM.png)
 
-Leaderboards is an entirely new addition to our on-platform community! Now, you can see who has earned the most XP (gained by completing exercises and code challenges) to create more friendly competition. It's inspired by game leaderboards (i.e. Dota 2, League).
+Leaderboards is an entirely new addition to our On-Platform Community! Now, you can see who has earned the most XP (gained by completing exercises and code challenges) to create more friendly competition. It's inspired by game leaderboards (i.e. Dota 2, League).
 
 <div style={{ display: "flex", justifyContent: "center", marginBottom: "1.2rem", transform: "scale(.9)" }}>
   <a href="https://www.codedex.io/community/leaderboards" style={{ all: "unset" }} target="_blank" and rel="noopener noreferrer"><Button variant="yellow">View Leaderboard</Button></a>

--- a/blogs/2025/codedex-update-q3-2025.mdx
+++ b/blogs/2025/codedex-update-q3-2025.mdx
@@ -71,7 +71,7 @@ To help you get started, we’ve also included these one-click prompts:
 - ✨ Provide step-by-step instructions
 - ✨ Get feedback on your code
 
-**Note:** You’ll unlock Lumi once you reach 500 XP.
+**Note:** You’ll unlock Lumi automatically after gaining enough XP.
 
 <div
   style={{

--- a/blogs/2025/codedex-v1.mdx
+++ b/blogs/2025/codedex-v1.mdx
@@ -147,7 +147,7 @@ This is a partnership course with the team at GitHub Edu and Microsoft. It will 
 
 Visual learners, this one’s for you! We’re adding byte-sized walkthrough videos inside course exercises, so you’ll always have an instructor guiding you through the steps if you get stuck. We’re starting with Python and expanding to HTML next. Plus, we'll upload full chapter videos on YouTube so you can revisit them anytime. 📺 
 
-Feedback welcome! Please let us know what you think in [Discord](https://discord.gg/vSKEhP9fY2) or [On-platform Community](https://www.codedex.io/community).
+Feedback welcome! Please let us know what you think in [Discord](https://discord.gg/vSKEhP9fY2) or [On-Platform Community](https://www.codedex.io/community).
 
 <div style={{ display: "flex", justifyContent: "center", marginBottom: "1.2rem", transform: "scale(.9)" }}>
   <a style={{ all: "unset" }} href="https://www.codedex.io/python/02-hello-world" target="_blank" and rel="noopener noreferrer"><Button variant="yellow">See a walkthrough video</Button></a>

--- a/blogs/2025/codedex-v1.mdx
+++ b/blogs/2025/codedex-v1.mdx
@@ -147,7 +147,7 @@ This is a partnership course with the team at GitHub Edu and Microsoft. It will 
 
 Visual learners, this one’s for you! We’re adding byte-sized walkthrough videos inside course exercises, so you’ll always have an instructor guiding you through the steps if you get stuck. We’re starting with Python and expanding to HTML next. Plus, we'll upload full chapter videos on YouTube so you can revisit them anytime. 📺 
 
-Feedback welcome! Please let us know what you think in Discord or OPC.
+Feedback welcome! Please let us know what you think in [Discord](https://discord.gg/vSKEhP9fY2) or [On-platform Community](https://www.codedex.io/community).
 
 <div style={{ display: "flex", justifyContent: "center", marginBottom: "1.2rem", transform: "scale(.9)" }}>
   <a style={{ all: "unset" }} href="https://www.codedex.io/python/02-hello-world" target="_blank" and rel="noopener noreferrer"><Button variant="yellow">See a walkthrough video</Button></a>

--- a/blogs/2025/how-to-ace-your-computer-science-classes-with-codedex.mdx
+++ b/blogs/2025/how-to-ace-your-computer-science-classes-with-codedex.mdx
@@ -165,7 +165,7 @@ This month, we’re kicking off the [Personal Portfolio Challenge](https://www.c
 
 ![](https://i.imgur.com/shL4vhm.png)
 
-Join the THOUSANDS of college students on our Discord channel. Just like a CS class, we have specific help channels that you can pop into to ask questions about certain concepts or topics! It's unlockable at 100 XP.
+Join the THOUSANDS of college students on our [Discord](https://discord.gg/vSKEhP9fY2) channel. Just like a CS class, we have specific help channels that you can pop into to ask questions about certain concepts or topics!
 
 ---
 

--- a/blogs/2025/how-to-ace-your-computer-science-classes-with-codedex.mdx
+++ b/blogs/2025/how-to-ace-your-computer-science-classes-with-codedex.mdx
@@ -165,7 +165,7 @@ This month, we’re kicking off the [Personal Portfolio Challenge](https://www.c
 
 ![](https://i.imgur.com/shL4vhm.png)
 
-Join the THOUSANDS of college students on our [Discord](https://discord.gg/vSKEhP9fY2) channel. Just like a CS class, we have specific help channels that you can pop into to ask questions about certain concepts or topics!
+Join the THOUSANDS of college students on our [Discord](https://discord.gg/vSKEhP9fY2) server. Just like a CS class, we have specific help channels that you can pop into to ask questions about certain concepts or topics!
 
 ---
 

--- a/blogs/2025/what-to-do-when-you-dont-have-a-tech-internship.mdx
+++ b/blogs/2025/what-to-do-when-you-dont-have-a-tech-internship.mdx
@@ -208,7 +208,7 @@ Even though times are tough, you can find spaces where you feel welcome and empo
 
 ![me in different communities](https://i.imgur.com/o6lzhVi.png)
 
-If you're not sure where to start, check out [Codédex OPC](https://www.codedex.io/community) or Discord (unlocked at 100XP)!
+If you're not sure where to start, check out [Codédex OPC](https://www.codedex.io/community) or our [Discord](https://discord.gg/vSKEhP9fY2)!
 
 <div style={{ display: "flex", justifyContent: "center", marginBottom: "1.2rem", transform: "scale(.9)" }}>
   <a href="https://www.codedex.io/community" style={{ all: "unset" }} target="_blank" and rel="noopener noreferrer"><Button variant="yellow">Join community ⋆˙⟡</Button></a>


### PR DESCRIPTION
## Description
Adds open invite links to previously gated mentions of Discord and removes active references to XP. 

## Additional changes and fixes 🧹
- Removes some backdoor links to project pages for certificates.
- Removes obsolete Typeform links.
- Updates UGC Typeform link.
- Rewrites some brittle language related to XP for other features to keep them from becoming inaccurate.

> [!note]
> Using the original stable Discord invite link here, instead of the vanity url which depends on Discord server boosts. 